### PR TITLE
Lock into laravel 5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": ">=7.1.3",
-        "laravel/framework": "^5.7"
+        "laravel/framework": "~5.7.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true


### PR DESCRIPTION
Laravel does not follow normal semantic versioning,  so a minor may be a BC break.
Using the ~ notation we make sure we dont update to 5.8

See also: https://getcomposer.org/doc/articles/versions.md#tilde-version-range-