### PR TITLE
Change publish path for views to include the vendor/ folder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,10 @@
         {
             "name": "Daan de Waard",
             "email": "daan.de.waard@hz.nl"
+        },
+        {
+            "name": "Daniel de Cloet",
+            "email": "djdecloet@gmail.com"
         }
     ],
     "autoload": {

--- a/src/Console/CoreUIMakeCommand.php
+++ b/src/Console/CoreUIMakeCommand.php
@@ -23,7 +23,7 @@ class CoreUIMakeCommand extends AuthMakeCommand
         ];
 
         foreach ($views as $stub => $view) {
-            copy(__DIR__.'/stubs/make/views/' . $stub, base_path('resources/views/' . $view));
+            copy(__DIR__.'/stubs/make/views/' . $stub, base_path('resources/views/vendor/' . $view));
         }
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -80,7 +80,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     private function publishViews(): void
     {
         $this->publishes([
-            $this->getPathFromPackageRoot('resources/views/') => resource_path('views/coreui'),
+            $this->getPathFromPackageRoot('resources/views/') => resource_path('views/vendor/coreui'),
         ], 'views');
     }
 


### PR DESCRIPTION
Changes publish console command to put the views in the `./resources/views/vendor/coreui` folder, instead of `./resources/views/coreui`, allowing users to edit the published views as they see fit.