### PR TITLE
Update package to support Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "require": {
         "php": "^7.2",
-        "laravel/framework": "^6.0"
+        "laravel/framework": "^8.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "laravel/framework": "^8.0",
         "laravel/ui": "^3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
     },
     "require": {
         "php": "^7.2",
-        "laravel/framework": "^8.0"
+        "laravel/framework": "^8.0",
+        "laravel/ui": "^3.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/src/Console/CoreUIAuthCommand.php
+++ b/src/Console/CoreUIAuthCommand.php
@@ -42,6 +42,8 @@ class CoreUIAuthCommand extends Command
      */
     public function handle()
     {
+        $this->callSilent('ui:controllers');
+
         $this->ensureDirectoriesExist();
         $this->exportViews();
 

--- a/src/Console/stubs/routes.stub
+++ b/src/Console/stubs/routes.stub
@@ -1,4 +1,4 @@
 
 Auth::routes();
 
-Route::get('/home', 'HomeController@index')->name('home');
+Route::get('/home', ['\App\Http\Controllers\HomeController', 'index'])->name('home');


### PR DESCRIPTION
Related to #41 

This PR is to update the plugin to be compatible with the most recent release of Laravel. Not to implement the new and awesome features that come packed with it, like [Blade Components](https://laravel.com/docs/7.x/upgrade#the-blade-component-method) or [Jetstream](https://jetstream.laravel.com/).

## Functionality tested
The following list of actions has been tested by running them in a fresh project. `laravel new test-project`
- [x] Publishing assets
- [x] Running `ui:coreui`
- [x] Publishing and editing coreui config
- [x] Gate functionality
- [x] Publishing and editing coreui view
- [x] Publishing and editing coreui language files

## Changelog
- Change composer requirements.
    - Change `php ^7.2` => `php ^7.3`
    - Change `laravel/framework ^6.0` => `laravel/framework ^8.0`.
    - Add `laravel/ui ^3.0`.
- Change `ui:coreui` command to also run `ui:controllers`
- Change format of `src/Console/stubs/routes.stub` to be functional with Laravel 8